### PR TITLE
fix(parser): Remove PHP warnings on unknown modifier '\'

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -110,7 +110,7 @@ class Parser
      */
     protected function getEscapedPatternString($search)
     {
-        $escaped = ['(',')','.',':','^','$','[',']','?','!','+','=','*',',','{','}','\\','-'];
+        $escaped = ['(',')','.',':','^','$','[',']','?','!','+','=','*',',','{','}','/','\\','-'];
 
         return implode('', array_map(function($char) use ($escaped) {
             if(!in_array($char, $escaped)) return $char;


### PR DESCRIPTION
They say that `A picture is worth a thousand words`...

![image](https://user-images.githubusercontent.com/4632429/117041370-7f121a80-acd0-11eb-9950-eb36ff5aedeb.png)

This `WARNING` is thrown while parsing `Price` objects from strings. This is due to the regex pattern generator not knowing that the forward slash (`/`) character should be escaped.

More specifically, this warning is raised when the following currency symbols are being tested in the regex:
| Currency Code | Symbol | Generated Pattern (Error Highlighted) |
| -------------------- | ---------- | ------- |
| PAB                  | B/.        | ![image](https://user-images.githubusercontent.com/4632429/117042169-3dce3a80-acd1-11eb-9beb-96319462a568.png) |
| PEN                  | S/.        | ![image](https://user-images.githubusercontent.com/4632429/117042257-58081880-acd1-11eb-9e58-303e1f330286.png) |

In order to fix this, we only need to flag the forward character (`/`) as part of the escaped regex characters, which is what this little PR does.