### PR TITLE
Add PHP 8.1 compatibility & Fix minimum PHP version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": "^7.4|^8.0",
         "brick/money": "0.5.*"
     },
     "require-dev": {

--- a/src/Formatting/CustomFormatter.php
+++ b/src/Formatting/CustomFormatter.php
@@ -12,7 +12,7 @@ class CustomFormatter extends Formatter
     protected $name;
 
     /**
-     * The custom formatter function 
+     * The custom formatter function
      *
      * @var callable
      */
@@ -52,6 +52,10 @@ class CustomFormatter extends Formatter
      */
     public function is($name = null)
     {
+        if (is_null($name)) {
+            return is_null($this->name);
+        }
+
         return strtolower($name) === strtolower($this->name);
     }
 

--- a/src/Price.php
+++ b/src/Price.php
@@ -268,7 +268,7 @@ class Price implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $excl = $this->exclusive();
         $incl = $this->inclusive();


### PR DESCRIPTION
I am not sure if this should be part of a new major release or if a minor would suffice.

I think a minor version would work, seeing as the addition of the 7.4 requirement would mean anyone on a lower version of PHP just won't get upgraded automatically.

I suggest we at least attempt to keep 7.4 compatibility until November 28, 2022, the official end of support for that PHP version. Unless we really really need 8.0 features, but it seems a bit unlikely.

Any thoughts?