### PR TITLE
[3.x] Allow RationalMoney instances as base price

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ $price = Price::EUR(600, 5)
 These classes have to implement the [`Whitecube\Price\PriceAmendable`](https://github.com/whitecube/php-prices/blob/master/src/PriceAmendable.php) interface, which then looks more or less like this:
 
 ```php
-use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Modifier;
 use Whitecube\Price\PriceAmendable;
@@ -429,14 +429,14 @@ class SomeRandomModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
         if(date('j') > 1) {
             // Do not apply if it's not the first day of the month

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "brick/money": "0.5.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "brick/money": "0.5.*"
+        "brick/money": "0.8.*"
     },
     "require-dev": {
         "pestphp/pest": "^1.0"

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -38,7 +38,7 @@ class Calculator
     /**
      * Return the result for the "VAT" Money build
      */
-    public function vat(bool $perUnit): mixed
+    public function vat(bool $perUnit): array|AbstractMoney
     {
         return $this->getCached('vat', $perUnit)
             ?? $this->setCached('vat', $perUnit, $this->getVatResult($perUnit));
@@ -65,7 +65,7 @@ class Calculator
     /**
      * Retrieve a cached value for key and unit mode
      */
-    protected function getCached(string $key, bool $perUnit): mixed
+    protected function getCached(string $key, bool $perUnit): null|array|AbstractMoney
     {
         return $this->cache[$key][$perUnit ? 'unit' : 'all'] ?? null;
     }
@@ -73,7 +73,7 @@ class Calculator
     /**
      * Set a cached value for key and unit mode
      */
-    protected function setCached(string $key, bool $perUnit, mixed $result): mixed
+    protected function setCached(string $key, bool $perUnit, array|AbstractMoney $result): array|AbstractMoney
     {
         $this->cache[$key][$perUnit ? 'unit' : 'all'] = $result;
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -3,6 +3,7 @@
 namespace Whitecube\Price;
 
 use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 
 class Calculator
 {
@@ -47,7 +48,7 @@ class Calculator
      * Return the result for the "VAT" Money build
      *
      * @param bool $perUnit
-     * @return \Brick\Money\Money
+     * @return array
      */
     public function vat($perUnit)
     {
@@ -156,7 +157,7 @@ class Calculator
      * Compute the VAT
      *
      * @param bool $perUnit
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
     protected function getVatResult($perUnit)
     {
@@ -198,11 +199,11 @@ class Calculator
      * @param array $result
      * @param bool $perUnit
      * @param bool $postVat
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
      * @return \Brick\Money\Money
      */
-    protected function applyModifier(PriceAmendable $modifier, array $result, $perUnit, $postVat = false, Money $exclusive = null, Vat $vat = null)
+    protected function applyModifier(PriceAmendable $modifier, array $result, $perUnit, $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null)
     {
         $updated = $modifier->apply($result['amount'], $this->price->units(), $perUnit, $exclusive, $vat);
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -4,28 +4,22 @@ namespace Whitecube\Price;
 
 use Brick\Money\Money;
 use Brick\Money\AbstractMoney;
+use Whitecube\Price\Price;
 
 class Calculator
 {
     /**
      * The price configuration
-     *
-     * @var \Whitecube\Price\Price
      */
-    private $price;
+    private Price $price;
 
     /**
      * The previously calculated amounts
-     *
-     * @var array
      */
-    private $cache = [];
+    private array $cache = [];
 
     /**
      * Create a new calculator
-     *
-     * @param \Whitecube\Price\Price $price
-     * @return void
      */
     public function __construct(Price $price)
     {
@@ -34,11 +28,8 @@ class Calculator
 
     /**
      * Return the result for the "before VAT" Money build
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    public function exclusiveBeforeVat($perUnit)
+    public function exclusiveBeforeVat(bool $perUnit): array
     {
         return $this->getCached('exclusive_before_vat', $perUnit)
             ?? $this->setCached('exclusive_before_vat', $perUnit, $this->getExclusiveBeforeVatResult($perUnit));
@@ -46,11 +37,8 @@ class Calculator
 
     /**
      * Return the result for the "VAT" Money build
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    public function vat($perUnit)
+    public function vat(bool $perUnit): mixed
     {
         return $this->getCached('vat', $perUnit)
             ?? $this->setCached('vat', $perUnit, $this->getVatResult($perUnit));
@@ -58,11 +46,8 @@ class Calculator
 
     /**
      * Return the result for the "after VAT" Money build
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    public function exclusiveAfterVat($perUnit)
+    public function exclusiveAfterVat(bool $perUnit): array
     {
         return $this->getCached('exclusive_after_vat', $perUnit)
             ?? $this->setCached('exclusive_after_vat', $perUnit, $this->getExclusiveAfterVatResult($perUnit));
@@ -70,11 +55,8 @@ class Calculator
 
     /**
      * Return the result for the complete Money build
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    public function inclusive($perUnit)
+    public function inclusive(bool $perUnit): array
     {
         return $this->getCached('inclusive', $perUnit)
             ?? $this->setCached('inclusive', $perUnit, $this->getInclusiveResult($perUnit));
@@ -82,25 +64,16 @@ class Calculator
 
     /**
      * Retrieve a cached value for key and unit mode
-     *
-     * @param string $key
-     * @param bool $perUnit
-     * @return null|array
      */
-    protected function getCached($key, $perUnit)
+    protected function getCached(string $key, bool $perUnit): mixed
     {
         return $this->cache[$key][$perUnit ? 'unit' : 'all'] ?? null;
     }
 
     /**
      * Set a cached value for key and unit mode
-     *
-     * @param string $key
-     * @param bool $perUnit
-     * @param array $result
-     * @return array
      */
-    protected function setCached($key, $perUnit, $result)
+    protected function setCached(string $key, bool $perUnit, mixed $result): mixed
     {
         $this->cache[$key][$perUnit ? 'unit' : 'all'] = $result;
 
@@ -109,11 +82,8 @@ class Calculator
 
     /**
      * Compute the price for one unit before VAT is applied
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    protected function getExclusiveBeforeVatResult($perUnit)
+    protected function getExclusiveBeforeVatResult(bool $perUnit): array
     {
         $modifiers = $this->price->getVatModifiers(false);
 
@@ -129,11 +99,8 @@ class Calculator
 
     /**
      * Compute the price for one unit after VAT is applied
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    protected function getExclusiveAfterVatResult($perUnit)
+    protected function getExclusiveAfterVatResult(bool $perUnit): array
     {
         $modifiers = $this->price->getVatModifiers(true);
 
@@ -155,11 +122,8 @@ class Calculator
 
     /**
      * Compute the VAT
-     *
-     * @param bool $perUnit
-     * @return \Brick\Money\AbstractMoney
      */
-    protected function getVatResult($perUnit)
+    protected function getVatResult(bool $perUnit): AbstractMoney
     {
         $vat = $this->price->vat(true);
 
@@ -174,11 +138,8 @@ class Calculator
 
     /**
      * Compute the complete price
-     *
-     * @param bool $perUnit
-     * @return array
      */
-    protected function getInclusiveResult($perUnit)
+    protected function getInclusiveResult(bool $perUnit): array
     {
         $result = $this->exclusiveBeforeVat($perUnit);
 
@@ -194,16 +155,8 @@ class Calculator
 
     /**
      * Compute the price for one unit before VAT is applied
-     *
-     * @param \Whitecube\Price\PriceAmendable $modifier
-     * @param array $result
-     * @param bool $perUnit
-     * @param bool $postVat
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return \Brick\Money\Money
      */
-    protected function applyModifier(PriceAmendable $modifier, array $result, $perUnit, $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null)
+    protected function applyModifier(PriceAmendable $modifier, array $result, $perUnit, $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null): array
     {
         $updated = $modifier->apply($result['amount'], $this->price->units(), $perUnit, $exclusive, $vat);
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -156,7 +156,7 @@ class Calculator
     /**
      * Compute the price for one unit before VAT is applied
      */
-    protected function applyModifier(PriceAmendable $modifier, array $result, $perUnit, $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null): array
+    protected function applyModifier(PriceAmendable $modifier, array $result, bool $perUnit, bool $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null): array
     {
         $updated = $modifier->apply($result['amount'], $this->price->units(), $perUnit, $exclusive, $vat);
 

--- a/src/Concerns/FormatsPrices.php
+++ b/src/Concerns/FormatsPrices.php
@@ -9,30 +9,21 @@ trait FormatsPrices
 {
     /**
      * The defined custom formatters.
-     *
-     * @var array
      */
-    static protected $formatters = [];
+    static protected array $formatters = [];
 
     /**
      * Formats the given monetary value into the application's currently preferred format.
-     *
-     * @param array $arguments
-     * @return string
      */
-    static public function format(...$arguments)
+    static public function format(...$arguments): ?string
     {
         return static::callFormatter(null, ...$arguments);
     }
 
     /**
      * Formats the given monetary value into the application's currently preferred format.
-     *
-     * @param null|string $name
-     * @param array $arguments
-     * @return string
      */
-    static protected function callFormatter($name, ...$arguments)
+    static protected function callFormatter(?string $name, ...$arguments): ?string
     {
         return static::getAssignedFormatter($name)->call($arguments);
     }
@@ -40,12 +31,8 @@ trait FormatsPrices
     /**
      * Formats the given monetary value using the package's default formatter.
      * This static method is hardcoded in order to prevent overwriting.
-     *
-     * @param string $value
-     * @param null|string $locale
-     * @return string
      */
-    static public function formatDefault($value, $locale = null)
+    static public function formatDefault(mixed $value, ?string $locale = null): string
     {
         return static::getDefaultFormatter()->call([$value, $locale]);
     }
@@ -53,11 +40,8 @@ trait FormatsPrices
     /**
      * Formats the given monetary value using the package's default formatter.
      * This static method is hardcoded in order to prevent overwriting.
-     *
-     * @param mixed $formatter
-     * @return \Whitecube\Price\CustomFormatter
      */
-    static public function formatUsing($formatter) : CustomFormatter
+    static public function formatUsing(mixed $formatter): CustomFormatter
     {
         if(is_string($formatter) && is_a($formatter, CustomFormatter::class, true)) {
             $instance = new $formatter;
@@ -76,11 +60,8 @@ trait FormatsPrices
 
     /**
      * Returns the correct formatter for the requested context
-     *
-     * @param null|string $name
-     * @return \Whitecube\Price\Formatter
      */
-    static protected function getAssignedFormatter($name = null) : Formatter
+    static protected function getAssignedFormatter(?string $name = null): Formatter
     {
         foreach (static::$formatters as $formatter) {
             if ($formatter->is($name)) return $formatter;
@@ -91,20 +72,16 @@ trait FormatsPrices
 
     /**
      * Returns the package's default formatter
-     *
-     * @return \Whitecube\Price\Formatter
      */
-    static protected function getDefaultFormatter() : Formatter
+    static protected function getDefaultFormatter(): Formatter
     {
         return new Formatter();
     }
 
     /**
      * Unsets all the previously defined custom formatters.
-     *
-     * @return void
      */
-    static public function forgetAllFormatters()
+    static public function forgetAllFormatters(): void
     {
         static::$formatters = [];
     }

--- a/src/Concerns/FormatsPrices.php
+++ b/src/Concerns/FormatsPrices.php
@@ -4,6 +4,8 @@ namespace Whitecube\Price\Concerns;
 
 use Whitecube\Price\Formatting\Formatter;
 use Whitecube\Price\Formatting\CustomFormatter;
+use Brick\Money\AbstractMoney;
+use Whitecube\Price\Price;
 
 trait FormatsPrices
 {
@@ -32,7 +34,7 @@ trait FormatsPrices
      * Formats the given monetary value using the package's default formatter.
      * This static method is hardcoded in order to prevent overwriting.
      */
-    static public function formatDefault(mixed $value, ?string $locale = null): string
+    static public function formatDefault(AbstractMoney|Price $value, ?string $locale = null): string
     {
         return static::getDefaultFormatter()->call([$value, $locale]);
     }
@@ -41,7 +43,7 @@ trait FormatsPrices
      * Formats the given monetary value using the package's default formatter.
      * This static method is hardcoded in order to prevent overwriting.
      */
-    static public function formatUsing(mixed $formatter): CustomFormatter
+    static public function formatUsing(string|callable|CustomFormatter $formatter): CustomFormatter
     {
         if(is_string($formatter) && is_a($formatter, CustomFormatter::class, true)) {
             $instance = new $formatter;
@@ -49,8 +51,6 @@ trait FormatsPrices
             $instance = $formatter;
         } elseif (is_callable($formatter)) {
             $instance = new CustomFormatter($formatter);
-        } else {
-            throw new \InvalidArgumentException('Price formatter should be callable or extend "\\Whitecube\\Price\\CustomFormatter". "' . gettype($formatter) . '" provided.');
         }
 
         static::$formatters[] = $instance;

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -13,7 +13,7 @@ trait HasModifiers
     /**
      * Add a tax modifier
      */
-    public function addTax(mixed $modifier, ...$arguments): static
+    public function addTax(string|callable|AbstractMoney|Price|PriceAmendable $modifier, ...$arguments): static
     {
         return $this->addModifier(Modifier::TYPE_TAX, $modifier, ...$arguments);
     }
@@ -21,7 +21,7 @@ trait HasModifiers
     /**
      * Add a discount modifier
      */
-    public function addDiscount(mixed $modifier, ...$arguments): static
+    public function addDiscount(string|callable|AbstractMoney|Price|PriceAmendable $modifier, ...$arguments): static
     {
         return $this->addModifier(Modifier::TYPE_DISCOUNT, $modifier, ...$arguments);
     }
@@ -29,7 +29,7 @@ trait HasModifiers
     /**
      * Add a price modifier
      */
-    public function addModifier(string $type, mixed $modifier, ...$arguments): static
+    public function addModifier(string $type, string|callable|AbstractMoney|Price|PriceAmendable $modifier, ...$arguments): static
     {
         $this->modifiers[] = $this->makeModifier($type, $modifier, $arguments);
 
@@ -42,7 +42,7 @@ trait HasModifiers
      * Create a usable modifier instance
      * @throws \InvalidArgumentException
      */
-    protected function makeModifier(string $type, mixed $modifier, array $arguments = []): PriceAmendable
+    protected function makeModifier(string $type, string|callable|AbstractMoney|Price|PriceAmendable $modifier, array $arguments = []): PriceAmendable
     {
         if(is_string($modifier) && class_exists($modifier)) {
             $modifier = new $modifier(...$arguments);
@@ -52,8 +52,8 @@ trait HasModifiers
             return $modifier->setType($type);
         }
 
-        if(is_null($modifier) || $modifier === '') {
-            throw new \InvalidArgumentException('Price modifier cannot be null or empty.');
+        if($modifier === '') {
+            throw new \InvalidArgumentException('Price modifier cannot be empty.');
         }
 
         $instance = (new Modifier)->setType($type);
@@ -66,12 +66,6 @@ trait HasModifiers
 
         if(is_a($modifier, Price::class)) {
             $modifier = $modifier->inclusive();
-        }
-
-        if(is_object($modifier) && ! is_a($modifier, AbstractMoney::class)) {
-            throw new \InvalidArgumentException('Price modifier instance should implement "' . PriceAmendable::class . '".');
-        } elseif (! is_object($modifier) && ! is_numeric($modifier)) {
-            throw new \InvalidArgumentException('Price modifier cannot be of type ' . gettype($modifier) . '.');
         }
 
         return $instance->add($modifier, Price::getRounding('exclusive'));

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -5,6 +5,7 @@ namespace Whitecube\Price\Concerns;
 use Whitecube\Price\Price;
 use Whitecube\Price\Modifier;
 use Whitecube\Price\PriceAmendable;
+use Brick\Money\AbstractMoney;
 use Brick\Money\Money;
 
 trait HasModifiers
@@ -85,7 +86,7 @@ trait HasModifiers
             $modifier = $modifier->inclusive();
         }
 
-        if(is_object($modifier) && ! is_a($modifier, Money::class)) {
+        if(is_object($modifier) && ! is_a($modifier, AbstractMoney::class)) {
             throw new \InvalidArgumentException('Price modifier instance should implement "' . PriceAmendable::class . '".');
         } elseif (! is_object($modifier) && ! is_numeric($modifier)) {
             throw new \InvalidArgumentException('Price modifier cannot be of type ' . gettype($modifier) . '.');

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -12,37 +12,24 @@ trait HasModifiers
 {
     /**
      * Add a tax modifier
-     *
-     * @param mixed $modifier
-     * @param array $arguments
-     * @return $this
      */
-    public function addTax($modifier, ...$arguments)
+    public function addTax(mixed $modifier, ...$arguments): static
     {
         return $this->addModifier(Modifier::TYPE_TAX, $modifier, ...$arguments);
     }
 
     /**
      * Add a discount modifier
-     *
-     * @param mixed $modifier
-     * @param array $arguments
-     * @return $this
      */
-    public function addDiscount($modifier, ...$arguments)
+    public function addDiscount(mixed $modifier, ...$arguments): static
     {
         return $this->addModifier(Modifier::TYPE_DISCOUNT, $modifier, ...$arguments);
     }
 
     /**
      * Add a price modifier
-     *
-     * @param string $type
-     * @param mixed $modifier
-     * @param array $arguments
-     * @return $this
      */
-    public function addModifier($type, $modifier, ...$arguments)
+    public function addModifier(string $type, mixed $modifier, ...$arguments): static
     {
         $this->modifiers[] = $this->makeModifier($type, $modifier, $arguments);
 
@@ -53,14 +40,9 @@ trait HasModifiers
 
     /**
      * Create a usable modifier instance
-     *
-     * @param string $type
-     * @param mixed $modifier
-     * @param array $arguments
-     * @return \Whitecube\Price\PriceAmendable
      * @throws \InvalidArgumentException
      */
-    protected function makeModifier($type, $modifier, $arguments = [])
+    protected function makeModifier(string $type, mixed $modifier, array $arguments = []): PriceAmendable
     {
         if(is_string($modifier) && class_exists($modifier)) {
             $modifier = new $modifier(...$arguments);
@@ -98,11 +80,8 @@ trait HasModifiers
     /**
      * Get the defined modifiers from before or after the
      * VAT value should have been applied
-     *
-     * @param bool $postVat
-     * @return array
      */
-    public function getVatModifiers(bool $postVat)
+    public function getVatModifiers(bool $postVat): array
     {
         return array_filter($this->modifiers, function($modifier) use ($postVat) {
             return $modifier->appliesAfterVat() === $postVat;
@@ -111,12 +90,8 @@ trait HasModifiers
 
     /**
      * Return the current modifications history
-     *
-     * @param bool $perUnit
-     * @param null|string $type
-     * @return array
      */
-    public function modifications($perUnit = false, $type = null)
+    public function modifications(bool $perUnit = false, ?string $type = null): array
     {
         $result = $this->build()->inclusive($perUnit ? true : false);
 
@@ -131,34 +106,24 @@ trait HasModifiers
 
     /**
      * Return the modification total for all discounts
-     *
-     * @param bool $perUnit
-     * @return \Brick\Money\Money
      */
-    public function discounts($perUnit = false)
+    public function discounts(bool $perUnit = false): Money
     {
         return $this->modifiers($perUnit, Modifier::TYPE_DISCOUNT);
     }
 
     /**
      * Return the modification total for all taxes
-     *
-     * @param bool $perUnit
-     * @return \Brick\Money\Money
      */
-    public function taxes($perUnit = false)
+    public function taxes(bool $perUnit = false): Money
     {
         return $this->modifiers($perUnit, Modifier::TYPE_TAX);
     }
 
     /**
      * Return the modification total for a given type
-     *
-     * @param bool $perUnit
-     * @param null|string $type
-     * @return \Brick\Money\Money
      */
-    public function modifiers($perUnit = false, $type = null)
+    public function modifiers(bool $perUnit = false, ?string $type = null): Money
     {
         $amount = Money::zero($this->currency());
 

--- a/src/Concerns/HasUnits.php
+++ b/src/Concerns/HasUnits.php
@@ -6,11 +6,8 @@ trait HasUnits
 {
     /**
      * Define the total units count
-     *
-     * @param mixed $value
-     * @return $this
      */
-    public function setUnits($value)
+    public function setUnits(mixed $value): static
     {
         $this->invalidate();
         
@@ -21,10 +18,8 @@ trait HasUnits
 
     /**
      * Return the total units count
-     *
-     * @return float
      */
-    public function units()
+    public function units(): float
     {
         return $this->units;
     }

--- a/src/Concerns/HasUnits.php
+++ b/src/Concerns/HasUnits.php
@@ -5,6 +5,11 @@ namespace Whitecube\Price\Concerns;
 trait HasUnits
 {
     /**
+     * The quantity that needs to be applied to the base price
+     */
+    protected float $units;
+
+    /**
      * Define the total units count
      */
     public function setUnits(float|int|string $value): static

--- a/src/Concerns/HasUnits.php
+++ b/src/Concerns/HasUnits.php
@@ -7,7 +7,7 @@ trait HasUnits
     /**
      * Define the total units count
      */
-    public function setUnits(mixed $value): static
+    public function setUnits(float|int|string $value): static
     {
         $this->invalidate();
         

--- a/src/Concerns/HasVat.php
+++ b/src/Concerns/HasVat.php
@@ -8,11 +8,8 @@ trait HasVat
 {
     /**
      * Add a VAT value
-     *
-     * @param mixed $value
-     * @return $this
      */
-    public function setVat(mixed $value = null): static
+    public function setVat(null|BigNumber|int|float|string $value = null): static
     {
         $this->invalidate();
 

--- a/src/Concerns/HasVat.php
+++ b/src/Concerns/HasVat.php
@@ -3,8 +3,6 @@
 namespace Whitecube\Price\Concerns;
 
 use Whitecube\Price\Vat;
-use Brick\Money\Money;
-use Brick\Math\RoundingMode;
 
 trait HasVat
 {
@@ -14,7 +12,7 @@ trait HasVat
      * @param mixed $value
      * @return $this
      */
-    public function setVat($value = null)
+    public function setVat(mixed $value = null): static
     {
         $this->invalidate();
 
@@ -35,11 +33,8 @@ trait HasVat
 
     /**
      * Return the VAT definition object
-     *
-     * @param bool $withoutDefault
-     * @return null|\Whitecube\Price\Vat
      */
-    public function vat($withoutDefault = false)
+    public function vat(bool $withoutDefault = false): ?Vat
     {
         return $this->vat
             ?? ($withoutDefault ? null : new Vat(0, $this));

--- a/src/Concerns/OperatesOnBase.php
+++ b/src/Concerns/OperatesOnBase.php
@@ -3,8 +3,9 @@
 namespace Whitecube\Price\Concerns;
 
 use Whitecube\Price\Price;
-use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 use Brick\Money\Exception\MoneyMismatchException;
+use Brick\Money\Money;
 
 trait OperatesOnBase
 {
@@ -23,7 +24,7 @@ trait OperatesOnBase
 
         $result = call_user_func_array([$this->base, $method], $arguments);
 
-        if(! is_a($result, Money::class)) {
+        if(! is_a($result, AbstractMoney::class)) {
             return $result;
         }
 
@@ -76,12 +77,12 @@ trait OperatesOnBase
     /**
      * Compare the given "current" value to another value
      *
-     * @param \Brick\Money\Money $price
-     * @param \Brick\Money\Money $that
+     * @param \Brick\Money\AbstractMoney $price
+     * @param \Brick\Money\AbstractMoney $that
      * @return int
      * @throws \Brick\Money\Exception\MoneyMismatchException
      */
-    protected function compareMonies(Money $price, Money $that)
+    protected function compareMonies(AbstractMoney $price, AbstractMoney $that)
     {
         $priceCurrency = $price->getCurrency();
         $thatCurrency = $that->getCurrency();
@@ -98,7 +99,7 @@ trait OperatesOnBase
      *
      * @param mixed $value
      * @param string $method
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
     protected function valueToMoney($value, $method = 'inclusive')
     {
@@ -106,7 +107,7 @@ trait OperatesOnBase
             $value = $value->$method();
         }
 
-        if(is_a($value, Money::class)) {
+        if(is_a($value, AbstractMoney::class)) {
             return $value;
         }
 

--- a/src/Concerns/OperatesOnBase.php
+++ b/src/Concerns/OperatesOnBase.php
@@ -6,6 +6,7 @@ use Whitecube\Price\Price;
 use Brick\Money\AbstractMoney;
 use Brick\Money\Exception\MoneyMismatchException;
 use Brick\Money\Money;
+use Brick\Math\BigNumber;
 
 trait OperatesOnBase
 {
@@ -34,7 +35,7 @@ trait OperatesOnBase
     /**
      * Check if given value equals the price's base value
      */
-    public function equals(mixed $value): bool
+    public function equals(BigNumber|int|float|string|AbstractMoney|Price $value): bool
     {
         return $this->compareTo($value) === 0;
     }
@@ -42,7 +43,7 @@ trait OperatesOnBase
     /**
      * Compare a given value to the total inclusive value of this instance
      */
-    public function compareTo(mixed $value): int
+    public function compareTo(BigNumber|int|float|string|AbstractMoney|Price $value): int
     {
         return $this->compareMonies(
             $this->inclusive(),
@@ -53,7 +54,7 @@ trait OperatesOnBase
     /**
      * Compare a given value to the unitless base value of this instance
      */
-    public function compareBaseTo(mixed $value): int
+    public function compareBaseTo(BigNumber|int|float|string|AbstractMoney|Price $value): int
     {
         return $this->compareMonies(
             $this->base(),
@@ -80,7 +81,7 @@ trait OperatesOnBase
     /**
      * Transform a given value into a Money instance
      */
-    protected function valueToMoney(mixed $value, string $method = 'inclusive'): AbstractMoney
+    protected function valueToMoney(BigNumber|int|float|string|AbstractMoney|Price $value, string $method = 'inclusive'): AbstractMoney
     {
         if(is_a($value, Price::class)) {
             $value = $value->$method();

--- a/src/Concerns/OperatesOnBase.php
+++ b/src/Concerns/OperatesOnBase.php
@@ -11,12 +11,8 @@ trait OperatesOnBase
 {
     /**
      * Forward operations on the price's base value
-     *
-     * @param string $method
-     * @param array  $arguments
-     * @return $this|mixed
      */
-    public function __call($method, $arguments)
+    public function __call(string $method, array $arguments): mixed
     {
         $arguments = array_map(function($value) {
             return is_a($value, Price::class) ? $value->base() : $value;
@@ -37,22 +33,16 @@ trait OperatesOnBase
 
     /**
      * Check if given value equals the price's base value
-     *
-     * @param mixed $value
-     * @return bool
      */
-    public function equals($value)
+    public function equals(mixed $value): bool
     {
         return $this->compareTo($value) === 0;
     }
 
     /**
      * Compare a given value to the total inclusive value of this instance
-     *
-     * @param mixed $value
-     * @return int
      */
-    public function compareTo($value)
+    public function compareTo(mixed $value): int
     {
         return $this->compareMonies(
             $this->inclusive(),
@@ -62,11 +52,8 @@ trait OperatesOnBase
 
     /**
      * Compare a given value to the unitless base value of this instance
-     *
-     * @param mixed $value
-     * @return int
      */
-    public function compareBaseTo($value)
+    public function compareBaseTo(mixed $value): int
     {
         return $this->compareMonies(
             $this->base(),
@@ -76,13 +63,9 @@ trait OperatesOnBase
 
     /**
      * Compare the given "current" value to another value
-     *
-     * @param \Brick\Money\AbstractMoney $price
-     * @param \Brick\Money\AbstractMoney $that
-     * @return int
      * @throws \Brick\Money\Exception\MoneyMismatchException
      */
-    protected function compareMonies(AbstractMoney $price, AbstractMoney $that)
+    protected function compareMonies(AbstractMoney $price, AbstractMoney $that): int
     {
         $priceCurrency = $price->getCurrency();
         $thatCurrency = $that->getCurrency();
@@ -96,12 +79,8 @@ trait OperatesOnBase
 
     /**
      * Transform a given value into a Money instance
-     *
-     * @param mixed $value
-     * @param string $method
-     * @return \Brick\Money\AbstractMoney
      */
-    protected function valueToMoney($value, $method = 'inclusive')
+    protected function valueToMoney(mixed $value, string $method = 'inclusive'): AbstractMoney
     {
         if(is_a($value, Price::class)) {
             $value = $value->$method();

--- a/src/Concerns/ParsesPrices.php
+++ b/src/Concerns/ParsesPrices.php
@@ -5,6 +5,7 @@ namespace Whitecube\Price\Concerns;
 use Whitecube\Price\Price;
 use Whitecube\Price\Parser;
 use Brick\Money\Money;
+use Brick\Money\Currency;
 
 trait ParsesPrices
 {
@@ -12,7 +13,7 @@ trait ParsesPrices
      * Create an instance from a major-value string, with 
      * or without defined currency (in which case it guesses).
      */
-    static public function parse(string $value, mixed $currency = null, int $units = 1): Price
+    static public function parse(string $value, null|Currency|string|int $currency = null, int $units = 1): Price
     {
         $parser = new Parser($value);
 

--- a/src/Concerns/ParsesPrices.php
+++ b/src/Concerns/ParsesPrices.php
@@ -11,13 +11,8 @@ trait ParsesPrices
     /**
      * Create an instance from a major-value string, with 
      * or without defined currency (in which case it guesses).
-     *
-     * @param string $value
-     * @param null|mixed $currency
-     * @param int $units
-     * @return \Whitecube\Price\Price
      */
-    static public function parse($value, $currency = null, $units = 1)
+    static public function parse(string $value, mixed $currency = null, int $units = 1): Price
     {
         $parser = new Parser($value);
 

--- a/src/Formatting/CustomFormatter.php
+++ b/src/Formatting/CustomFormatter.php
@@ -2,42 +2,36 @@
 
 namespace Whitecube\Price\Formatting;
 
+use Closure;
+
 class CustomFormatter extends Formatter
 {
     /**
      * The defined name for this formatter
-     *
-     * @var null|string
      */
-    protected $name;
+    protected ?string $name = null;
 
     /**
      * The custom formatter function
-     *
-     * @var callable
      */
-    protected $closure;
+    protected ?Closure $closure = null;
 
     /**
      * Create a new formatter instance
-     *
-     * @param callable $closure
-     * @return void
      */
-    public function __construct(callable $closure = null)
+    public function __construct(?callable $closure = null)
     {
-        $this->closure = $closure;
+        if (! is_null($closure)) {
+            $this->closure = Closure::fromCallable($closure);
+        }
 
         return $this;
     }
 
     /**
      * Set ther formatter's name
-     *
-     * @param string $name
-     * @return this
      */
-    public function name(string $name)
+    public function name(string $name): static
     {
         $this->name = $name;
 
@@ -46,11 +40,8 @@ class CustomFormatter extends Formatter
 
     /**
      * Check if this formatter has the provided name
-     *
-     * @param null|string $name
-     * @return bool
      */
-    public function is($name = null)
+    public function is(?string $name = null): bool
     {
         if (is_null($name)) {
             return is_null($this->name);

--- a/src/Formatting/Formatter.php
+++ b/src/Formatting/Formatter.php
@@ -3,7 +3,7 @@
 namespace Whitecube\Price\Formatting;
 
 use NumberFormatter;
-use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 use Whitecube\Price\Vat;
 use Whitecube\Price\Price;
 
@@ -30,7 +30,7 @@ class Formatter
     {
         [$value, $locale] = $this->getMoneyAndLocale($arguments);
 
-        if(! is_a($value, Money::class)) {
+        if(! is_a($value, AbstractMoney::class)) {
             return null;
         }
 
@@ -64,9 +64,9 @@ class Formatter
      * @param mixed $value
      * @return null|\Brick\Money\Money
      */
-    protected function toMoney($value) : ?Money
+    protected function toMoney($value) : ?AbstractMoney
     {
-        if(is_a($value, Money::class)) {
+        if(is_a($value, AbstractMoney::class)) {
             return $value;
         }
 
@@ -88,7 +88,7 @@ class Formatter
      * @return string $locale
      * @return string
      */
-    protected function format(Money $value, string $locale) : string
+    protected function format(AbstractMoney $value, string $locale) : string
     {
         $currency = $value->getCurrency()->getCurrencyCode();
         $value = $value->getAmount()->toFloat();

--- a/src/Formatting/Formatter.php
+++ b/src/Formatting/Formatter.php
@@ -50,7 +50,7 @@ class Formatter
     /**
      * Get the Money instance from the provided value.
      */
-    protected function toMoney(mixed $value) : ?AbstractMoney
+    protected function toMoney(Price|AbstractMoney|Vat $value) : AbstractMoney
     {
         if(is_a($value, AbstractMoney::class)) {
             return $value;
@@ -63,8 +63,6 @@ class Formatter
         if (is_a($value, Vat::class)) {
             return $value->money();
         }
-
-        return null;
     }
 
     /**

--- a/src/Formatting/Formatter.php
+++ b/src/Formatting/Formatter.php
@@ -11,20 +11,14 @@ class Formatter
 {
     /**
      * Check if this formatter has the provided name
-     *
-     * @param null|string $name
-     * @return bool
      */
-    public function is($name = null)
+    public function is(?string $name = null): bool
     {
         return is_null($name);
     }
 
     /**
      * Run the formatter using the provided arguments
-     *
-     * @param array $arguments
-     * @return null|string
      */
     public function call(array $arguments) : ?string
     {
@@ -39,11 +33,6 @@ class Formatter
 
     /**
      * Extract the Money and locale arguments from the provided arguments array.
-     *
-     * @param array $arguments
-     * @param int $moneyIndex
-     * @param int $localeIndex
-     * @return array
      */
     protected function getMoneyAndLocale(array $arguments, int $moneyIndex = 0, int $localeIndex = 1) : array
     {
@@ -60,11 +49,8 @@ class Formatter
 
     /**
      * Get the Money instance from the provided value.
-     *
-     * @param mixed $value
-     * @return null|\Brick\Money\Money
      */
-    protected function toMoney($value) : ?AbstractMoney
+    protected function toMoney(mixed $value) : ?AbstractMoney
     {
         if(is_a($value, AbstractMoney::class)) {
             return $value;
@@ -83,10 +69,6 @@ class Formatter
 
     /**
      * Transform the money instance into a human-readable string
-     *
-     * @param \Brick\Money\Money $value
-     * @return string $locale
-     * @return string
      */
     protected function format(AbstractMoney $value, string $locale) : string
     {

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -9,8 +9,6 @@ class Modifier implements PriceAmendable
 {
     /**
      * The default modifier types
-     *
-     * @var string
      */
     const TYPE_TAX = 'tax';
     const TYPE_DISCOUNT = 'discount';
@@ -18,57 +16,40 @@ class Modifier implements PriceAmendable
 
     /**
      * The effective modifier type
-     *
-     * @var null|string
      */
-    protected $type;
+    protected ?string $type = null;
 
     /**
      * The modifier's identifier
-     *
-     * @var null|string
      */
-    protected $key;
+    protected ?string $key = null;
 
     /**
      * The extra attributes that should be passed along
-     *
-     * @var array
      */
-    protected $attributes = [];
+    protected array $attributes = [];
 
     /**
      * Whether this modifier should be executed
      * before or after the VAT value has been computed.
-     *
-     * @var bool
      */
-    protected $postVat = false;
+    protected bool $postVat = false;
 
     /**
      * Whether this modifier covers a single unit
      * or the whole price regardless of its units.
-     *
-     * @var bool
      */
-    protected $perUnit = true;
+    protected bool $perUnit = true;
 
     /**
      * The modifications that should be applied to the price
-     *
-     * @var array
      */
-    protected $stack = [];
+    protected array $stack = [];
 
     /**
      * Create a new modifier instance
-     *
-     * @param mixed $callback
-     * @param null|string $type
-     * @param bool $pre
-     * @return static
      */
-    static public function of($configuration)
+    static public function of(array $configuration): static
     {
         return (new static())
             ->setType($configuration['type'] ?? null)
@@ -79,11 +60,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Define the modifier type (tax, discount, other, ...)
-     *
-     * @param null|string $type
-     * @return $this
      */
-    public function setType($type = null)
+    public function setType(?string $type = null): static
     {
         $this->type = $type;
 
@@ -92,21 +70,16 @@ class Modifier implements PriceAmendable
 
     /**
      * Return the modifier type (tax, discount, other, ...)
-     *
-     * @return string
      */
-    public function type() : string
+    public function type(): string
     {
         return $this->type ?: static::TYPE_UNDEFINED;
     }
 
     /**
      * Define the modifier's identification key
-     *
-     * @param null|string $key
-     * @return $this
      */
-    public function setKey($key = null)
+    public function setKey(?string $key = null): static
     {
         $this->key = $key;
 
@@ -115,21 +88,16 @@ class Modifier implements PriceAmendable
 
     /**
      * Return the modifier's identification key
-     *
-     * @return null|string
      */
-    public function key() : ?string
+    public function key(): ?string
     {
         return $this->key;
     }
 
     /**
      * Define the modifier's extra attributes
-     *
-     * @param array $attributes
-     * @return $this
      */
-    public function setAttributes(array $attributes = [])
+    public function setAttributes(array $attributes = []): static
     {
         $this->attributes = $attributes;
 
@@ -138,10 +106,8 @@ class Modifier implements PriceAmendable
     /**
      * Get the modifier attributes that should be saved in the
      * price modification history.
-     *
-     * @return null|array
      */
-    public function attributes() : ?array
+    public function attributes(): ?array
     {
         return $this->attributes ?: null;
     }
@@ -149,11 +115,8 @@ class Modifier implements PriceAmendable
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @param bool $postVat
-     * @return $this
      */
-    public function setPostVat($postVat = true)
+    public function setPostVat(bool $postVat = true): static
     {
         $this->postVat = $postVat;
 
@@ -163,10 +126,8 @@ class Modifier implements PriceAmendable
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @return bool
      */
-    public function appliesAfterVat() : bool
+    public function appliesAfterVat(): bool
     {
         return $this->postVat ? true : false;
     }
@@ -174,11 +135,8 @@ class Modifier implements PriceAmendable
     /**
      * Whether this modifier covers a single unit
      * or the whole price regardless of its units.
-     *
-     * @param bool $perUnit
-     * @return $this
      */
-    public function setPerUnit($perUnit = true)
+    public function setPerUnit(bool $perUnit = true): static
     {
         $this->perUnit = $perUnit;
 
@@ -188,21 +146,16 @@ class Modifier implements PriceAmendable
     /**
      * Whether this modifier covers a single unit
      * or the whole price regardless of its units.
-     *
-     * @return bool
      */
-    public function appliesPerUnit() : bool
+    public function appliesPerUnit(): bool
     {
         return $this->perUnit ? true : false;
     }
 
     /**
      * Add an addition modification to the stack
-     *
-     * @param array $arguments
-     * @return $this
      */
-    public function add(...$arguments)
+    public function add(...$arguments): static
     {
         $this->stack[] = [
             'method' => 'plus',
@@ -214,11 +167,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Add a substraction modification to the stack
-     *
-     * @param array $arguments
-     * @return $this
      */
-    public function subtract(...$arguments)
+    public function subtract(...$arguments): static
     {
         $this->stack[] = [
             'method' => 'minus',
@@ -230,11 +180,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Add a multiplication modification to the stack
-     *
-     * @param array $arguments
-     * @return $this
      */
-    public function multiply(...$arguments)
+    public function multiply(...$arguments): static
     {
         $this->stack[] = [
             'method' => 'multipliedBy',
@@ -246,11 +193,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Add a division modification to the stack
-     *
-     * @param array $arguments
-     * @return $this
      */
-    public function divide(...$arguments)
+    public function divide(...$arguments): static
     {
         $this->stack[] = [
             'method' => 'dividedBy',
@@ -262,12 +206,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Add a absolute modification to the stack
-     *
-     * @param mixed $that
-     * @param null|int $rounding
-     * @return $this
      */
-    public function abs()
+    public function abs(): static
     {
         $this->stack[] = [
             'method' => 'abs',
@@ -278,13 +218,6 @@ class Modifier implements PriceAmendable
 
     /**
      * Apply the modifier on the given Money instance
-     *
-     * @param \Brick\Money\AbstractMoney $build
-     * @param float $units
-     * @param bool $perUnit
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\AbstractMoney
      */
     public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
@@ -313,12 +246,8 @@ class Modifier implements PriceAmendable
 
     /**
      * Apply given stack action on the price being build
-     *
-     * @param array $action
-     * @param \Brick\Money\AbstractMoney $build
-     * @return \Brick\Money\AbstractMoney
      */
-    protected function applyStackAction($action, AbstractMoney $build)
+    protected function applyStackAction(array $action, AbstractMoney $build): AbstractMoney
     {
         return call_user_func_array([$build, $action['method']], $action['arguments'] ?? []);
     }

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -3,6 +3,7 @@
 namespace Whitecube\Price;
 
 use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 
 class Modifier implements PriceAmendable
 {
@@ -278,14 +279,14 @@ class Modifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
         if(! $this->stack) {
             return null;
@@ -296,7 +297,7 @@ class Modifier implements PriceAmendable
                 return $this->applyStackAction($action, $build);
             }
 
-            $argument = is_a($action['arguments'][0] ?? null, Money::class)
+            $argument = is_a($action['arguments'][0] ?? null, AbstractMoney::class)
                     ? $action['arguments'][0]
                     : Money::ofMinor($action['arguments'][0] ?? 0, $build->getCurrency());
 
@@ -314,10 +315,10 @@ class Modifier implements PriceAmendable
      * Apply given stack action on the price being build
      *
      * @param array $action
-     * @param \Brick\Money\Money $build
-     * @return \Brick\Money\Money
+     * @param \Brick\Money\AbstractMoney $build
+     * @return \Brick\Money\AbstractMoney
      */
-    protected function applyStackAction($action, Money $build)
+    protected function applyStackAction($action, AbstractMoney $build)
     {
         return call_user_func_array([$build, $action['method']], $action['arguments'] ?? []);
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -20,7 +20,7 @@ class Parser
     /**
      * Create a new Parser object
      */
-    public function __construct(mixed $value)
+    public function __construct(string|int|float $value)
     {
         $this->original = strval($value);
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -9,35 +9,26 @@ class Parser
 {
     /**
      * The available parsable currency symbols
-     *
-     * @var array
      */
-    static protected $symbols;
+    static protected ?array $symbols = null;
 
     /**
      * The original string value
-     *
-     * @var string
      */
-    protected $original;
+    protected string $original;
 
     /**
      * Create a new Parser object
-     *
-     * @param mixed $value
-     * @return void
      */
-    public function __construct($value)
+    public function __construct(mixed $value)
     {
         $this->original = strval($value);
     }
 
     /**
      * Find and transform the numeric value
-     *
-     * @return string
      */
-    public function extractValue()
+    public function extractValue(): string
     {
         $string = str_replace([',', ' ', ' '], ['.', '', ''], $this->original);
 
@@ -58,10 +49,8 @@ class Parser
 
     /**
      * Find the currency ISO-code
-     *
-     * @return null|string
      */
-    public function extractCurrency()
+    public function extractCurrency(): ?string
     {
         $symbols = static::getSymbols();
 
@@ -82,12 +71,8 @@ class Parser
 
     /**
      * Generate a Regex string for given currency
-     *
-     * @param \Brick\Money\Currency $currency
-     * @param null|string $symbol
-     * @return string
      */
-    protected function getCurrencyPattern(Currency $currency, $symbol = null)
+    protected function getCurrencyPattern(Currency $currency, ?string $symbol = null): string
     {
         $pattern = '/^(?:(?:.*?[^\d]?\s)|(?:.*?\d))?(';
         $pattern .= $this->getEscapedPatternString($currency->getCurrencyCode());
@@ -104,11 +89,8 @@ class Parser
 
     /**
      * Escape each character for the given regex string
-     *
-     * @param string $search
-     * @return string
      */
-    protected function getEscapedPatternString($search)
+    protected function getEscapedPatternString(string $search): string
     {
         $escaped = ['(',')','.',':','^','$','[',']','?','!','+','=','*',',','{','}','/','\\','-'];
 
@@ -120,10 +102,8 @@ class Parser
 
     /**
      * Get all the available currency symbols
-     *
-     * @return array
      */
-    static public function getSymbols()
+    static public function getSymbols(): array
     {
         if(is_null(static::$symbols)) {
             static::$symbols = static::loadSymbols();
@@ -134,11 +114,9 @@ class Parser
 
     /**
      * Try to load the available currency symbols
-     *
-     * @return array
      * @throws \RuntimeException
      */
-    static protected function loadSymbols()
+    static protected function loadSymbols(): array
     {
         $file = __DIR__ . '/../resources/symbols.php';
 

--- a/src/Price.php
+++ b/src/Price.php
@@ -41,11 +41,6 @@ class Price implements \JsonSerializable
     protected ?Vat $vat;
 
     /**
-     * The quantity that needs to be applied to the base price
-     */
-    protected float $units;
-
-    /**
      * The price modifiers to apply
      */
     protected array $modifiers = [];

--- a/src/Price.php
+++ b/src/Price.php
@@ -5,6 +5,8 @@ namespace Whitecube\Price;
 use Brick\Money\Money;
 use Brick\Money\ISOCurrencyProvider;
 use Brick\Math\RoundingMode;
+use Brick\Money\AbstractMoney;
+use Brick\Money\Context\CustomContext;
 
 class Price implements \JsonSerializable
 {
@@ -28,7 +30,7 @@ class Price implements \JsonSerializable
     /**
      * The root price
      *
-     * @var \Brick\Money\Money
+     * @var \Brick\Money\AbstractMoney
      */
     protected $base;
 
@@ -63,11 +65,11 @@ class Price implements \JsonSerializable
     /**
      * Create a new Price object
      *
-     * @param \Brick\Money\Money $base
+     * @param \Brick\Money\AbstractMoney $base
      * @param int $units
      * @return void
      */
-    public function __construct(Money $base, $units = 1)
+    public function __construct(AbstractMoney $base, $units = 1)
     {
         $this->base = $base;
         $this->setUnits($units);
@@ -134,10 +136,14 @@ class Price implements \JsonSerializable
     /**
      * Return the price's underlying context instance
      *
-     * @return \Brick\Money\Context
+     * @return null|\Brick\Money\Context
      */
     public function context()
     {
+        if (! method_exists($this->base, 'getContext')) {
+            return null;
+        }
+
         return $this->base->getContext();
     }
 
@@ -145,7 +151,7 @@ class Price implements \JsonSerializable
      * Return the price's base value
      *
      * @param bool $perUnit
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
     public function base($perUnit = true)
     {
@@ -159,7 +165,7 @@ class Price implements \JsonSerializable
      *
      * @param bool $perUnit
      * @param bool $includeAfterVat
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
     public function exclusive($perUnit = false, $includeAfterVat = false)
     {
@@ -178,7 +184,7 @@ class Price implements \JsonSerializable
      * Return the INCL. Money value
      *
      * @param bool $perUnit
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
     public function inclusive($perUnit = false)
     {
@@ -209,10 +215,10 @@ class Price implements \JsonSerializable
     /**
      * Split given amount into ~equal parts and return the smallest
      *
-     * @param \Brick\Money\Money $amount
-     * @return \Brick\Money\Money
+     * @param \Brick\Money\AbstractMoney $amount
+     * @return \Brick\Money\AbstractMoney
      */
-    public function perUnit(Money $amount)
+    public function perUnit(AbstractMoney $amount)
     {
         if($this->units === floatval(1)) {
             return $amount;
@@ -230,11 +236,11 @@ class Price implements \JsonSerializable
     /**
      * Multiply the given amount by the number of available units
      *
-     * @param \Brick\Money\Money $amount
+     * @param \Brick\Money\AbstractMoney $amount
      * @param null|int $rounding
-     * @return \Brick\Money\Money
+     * @return \Brick\Money\AbstractMoney
      */
-    public function applyUnits(Money $amount, int $rounding = null)
+    public function applyUnits(AbstractMoney $amount, int $rounding = null)
     {
         if(is_null($rounding)) {
             $rounding = static::getRounding('exclusive');
@@ -279,7 +285,7 @@ class Price implements \JsonSerializable
      */
     public function __toString()
     {
-        return $this->inclusive()->__toString();
+        return $this->inclusive()->to(new CustomContext(2), static::getRounding('vat'))->__toString();
     }
 
     /**

--- a/src/Price.php
+++ b/src/Price.php
@@ -67,7 +67,7 @@ class Price implements \JsonSerializable
     /**
      * Convenience Money methods for creating Price objects and value formatting
      */
-    public static function __callStatic(string $method, array $arguments): mixed
+    public static function __callStatic(string $method, array $arguments): null|string|static
     {
         if(strpos($method, 'format') === 0) {
             return static::callFormatter(substr($method, 6), ...$arguments);
@@ -257,14 +257,10 @@ class Price implements \JsonSerializable
      * Hydrate a price object from a json string/array
      * @throws \InvalidArgumentException
      */
-    public static function json(mixed $value): static
+    public static function json(string|array $value): static
     {
         if(is_string($value)) {
             $value = json_decode($value, true);
-        }
-
-        if(!is_array($value)) {
-            throw new \InvalidArgumentException('Cannot create Price from invalid argument (expects JSON string or Array)');
         }
 
         $base = Money::ofMinor($value['base'], $value['currency']);

--- a/src/Price.php
+++ b/src/Price.php
@@ -53,7 +53,7 @@ class Price implements \JsonSerializable
     /**
      * Create a new Price object
      */
-    public function __construct(AbstractMoney $base, int $units = 1)
+    public function __construct(AbstractMoney $base, float|int|string $units = 1)
     {
         $this->base = $base;
         $this->setUnits($units);

--- a/src/Price.php
+++ b/src/Price.php
@@ -7,7 +7,7 @@ use Brick\Money\ISOCurrencyProvider;
 use Brick\Math\RoundingMode;
 use Brick\Money\AbstractMoney;
 use Brick\Money\Context;
-use Brick\Money\Context\CustomContext;
+use Brick\Money\Context\DefaultContext;
 use Brick\Money\Currency;
 use Whitecube\Price\Vat;
 
@@ -228,7 +228,7 @@ class Price implements \JsonSerializable
      */
     public function __toString(): string
     {
-        return $this->inclusive()->to(new CustomContext(2), static::getRounding('vat'))->__toString();
+        return $this->inclusive()->to(new DefaultContext, static::getRounding('vat'))->__toString();
     }
 
     public function jsonSerialize(): array

--- a/src/PriceAmendable.php
+++ b/src/PriceAmendable.php
@@ -2,7 +2,7 @@
 
 namespace Whitecube\Price;
 
-use Brick\Money\Money;
+use Brick\Money\AbstractMoney;
 
 interface PriceAmendable
 {
@@ -47,12 +47,12 @@ interface PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money;
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney;
 }

--- a/src/PriceAmendable.php
+++ b/src/PriceAmendable.php
@@ -8,41 +8,30 @@ interface PriceAmendable
 {
     /**
      * Return the modifier type (tax, discount, other, ...)
-     *
-     * @return string
      */
-    public function type() : string;
+    public function type(): string;
 
     /**
      * Define the modifier type (tax, discount, other, ...)
-     *
-     * @param null|string $type
-     * @return $this
      */
-    public function setType($type = null);
+    public function setType(?string $type = null): static;
 
     /**
      * Return the modifier's identification key
-     *
-     * @return null|string
      */
-    public function key() : ?string;
+    public function key(): ?string;
 
     /**
      * Get the modifier attributes that should be saved in the
      * price modification history.
-     *
-     * @return null|array
      */
-    public function attributes() : ?array;
+    public function attributes(): ?array;
 
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @return bool
      */
-    public function appliesAfterVat() : bool;
+    public function appliesAfterVat(): bool;
 
     /**
      * Apply the modifier on the given Money instance

--- a/src/PriceAmendable.php
+++ b/src/PriceAmendable.php
@@ -43,5 +43,5 @@ interface PriceAmendable
      * @param null|\Whitecube\Price\Vat $vat
      * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney;
+    public function apply(AbstractMoney $build, float $units, bool $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney;
 }

--- a/src/Vat.php
+++ b/src/Vat.php
@@ -7,6 +7,7 @@ use Brick\Math\RoundingMode;
 use Brick\Money\AbstractMoney;
 use Brick\Money\Money;
 use Whitecube\Price\Price;
+use Brick\Math\BigNumber;
 
 class Vat
 {
@@ -23,7 +24,7 @@ class Vat
     /**
      * Create a new VAT value
      */
-    public function __construct(mixed $value, Price $price)
+    public function __construct(BigNumber|int|float|string $value, Price $price)
     {
         $this->price = $price;
         $this->percentage = BigDecimal::of($value);

--- a/src/Vat.php
+++ b/src/Vat.php
@@ -41,7 +41,7 @@ class Vat
     /**
      * Get the VAT's Money value
      */
-    public function money(bool $perUnit = false): Money
+    public function money(bool $perUnit = false): AbstractMoney
     {
         return $this->price->build()->vat($perUnit);
     }

--- a/src/Vat.php
+++ b/src/Vat.php
@@ -2,9 +2,9 @@
 
 namespace Whitecube\Price;
 
-use Brick\Money\Money;
 use Brick\Math\BigDecimal;
 use Brick\Math\RoundingMode;
+use Brick\Money\AbstractMoney;
 
 class Vat
 {
@@ -59,10 +59,10 @@ class Vat
     /**
      * Compute the VAT's values
      *
-     * @param \Brick\Money\Money $exclusive
-     * @return \Brick\Money\Money
+     * @param \Brick\Money\AbstractMoney $exclusive
+     * @return \Brick\Money\AbstractMoney
      */
-    public function apply(Money $exclusive)
+    public function apply(AbstractMoney $exclusive)
     {
         $multiplier = $this->percentage->dividedBy(100, $this->percentage->getScale() + 2, RoundingMode::UP);
 

--- a/src/Vat.php
+++ b/src/Vat.php
@@ -5,31 +5,25 @@ namespace Whitecube\Price;
 use Brick\Math\BigDecimal;
 use Brick\Math\RoundingMode;
 use Brick\Money\AbstractMoney;
+use Brick\Money\Money;
+use Whitecube\Price\Price;
 
 class Vat
 {
     /**
      * The price this VAT object belongsTo
-     *
-     * @var \Whitecube\Price\Price
      */
-    private $price;
+    private Price $price;
 
     /**
      * The VAT's percentage value
-     *
-     * @var \Brick\Math\BigDecimal
      */
-    protected $percentage;
+    protected BigDecimal $percentage;
 
     /**
      * Create a new VAT value
-     *
-     * @param mixed $value
-     * @param \Whitecube\Price\Price $price
-     * @return void
      */
-    public function __construct($value, Price $price)
+    public function __construct(mixed $value, Price $price)
     {
         $this->price = $price;
         $this->percentage = BigDecimal::of($value);
@@ -37,32 +31,24 @@ class Vat
 
     /**
      * Get the VAT's percentage float value
-     *
-     * @return float
      */
-    public function percentage()
+    public function percentage(): float
     {
         return $this->percentage->toFloat();
     }
 
     /**
      * Get the VAT's Money value
-     *
-     * @param bool $perUnit
-     * @return \Brick\Money\Money
      */
-    public function money($perUnit = false)
+    public function money(bool $perUnit = false): Money
     {
         return $this->price->build()->vat($perUnit);
     }
 
     /**
      * Compute the VAT's values
-     *
-     * @param \Brick\Money\AbstractMoney $exclusive
-     * @return \Brick\Money\AbstractMoney
      */
-    public function apply(AbstractMoney $exclusive)
+    public function apply(AbstractMoney $exclusive): AbstractMoney
     {
         $multiplier = $this->percentage->dividedBy(100, $this->percentage->getScale() + 2, RoundingMode::UP);
 

--- a/tests/Fixtures/AfterVatAmendableModifier.php
+++ b/tests/Fixtures/AfterVatAmendableModifier.php
@@ -6,6 +6,7 @@ use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
+use Brick\Money\AbstractMoney;
 
 class AfterVatAmendableModifier implements PriceAmendable
 {
@@ -74,14 +75,14 @@ class AfterVatAmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
         $tax = Money::ofMinor(100, 'EUR');
 

--- a/tests/Fixtures/AfterVatAmendableModifier.php
+++ b/tests/Fixtures/AfterVatAmendableModifier.php
@@ -12,28 +12,21 @@ class AfterVatAmendableModifier implements PriceAmendable
 {
     /**
      * The "set" modifier type (tax, discount, other, ...)
-     *
-     * @return null|string
      */
-    protected $type;
+    protected ?string $type;
 
     /**
      * Return the modifier type (tax, discount, other, ...)
-     *
-     * @return string
      */
-    public function type() : string
+    public function type(): string
     {
         return $this->type;
     }
 
     /**
      * Define the modifier type (tax, discount, other, ...)
-     *
-     * @param null|string $type
-     * @return $this
      */
-    public function setType($type = null)
+    public function setType(?string $type = null): static
     {
         $this->type = $type;
 
@@ -42,10 +35,8 @@ class AfterVatAmendableModifier implements PriceAmendable
 
     /**
      * Return the modifier's identification key
-     *
-     * @return null|string
      */
-    public function key() : ?string
+    public function key(): ?string
     {
         return 'after-vat';
     }
@@ -53,10 +44,8 @@ class AfterVatAmendableModifier implements PriceAmendable
     /**
      * Get the modifier attributes that should be saved in the
      * price modification history.
-     *
-     * @return null|array
      */
-    public function attributes() : ?array
+    public function attributes(): ?array
     {
         return null;
     }
@@ -64,23 +53,14 @@ class AfterVatAmendableModifier implements PriceAmendable
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @return bool
      */
-    public function appliesAfterVat() : bool
+    public function appliesAfterVat(): bool
     {
         return true;
     }
 
     /**
      * Apply the modifier on the given Money instance
-     *
-     * @param \Brick\Money\AbstractMoney $build
-     * @param float $units
-     * @param bool $perUnit
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\AbstractMoney
      */
     public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {

--- a/tests/Fixtures/AmendableModifier.php
+++ b/tests/Fixtures/AmendableModifier.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Fixtures;
 
-use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
+use Brick\Money\AbstractMoney;
 
 class AmendableModifier implements PriceAmendable
 {
@@ -74,14 +74,14 @@ class AmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
         return $build->multipliedBy(1.25, RoundingMode::HALF_UP);
     }

--- a/tests/Fixtures/AmendableModifier.php
+++ b/tests/Fixtures/AmendableModifier.php
@@ -11,28 +11,21 @@ class AmendableModifier implements PriceAmendable
 {
     /**
      * The "set" modifier type (tax, discount, other, ...)
-     *
-     * @return null|string
      */
-    protected $type;
+    protected ?string $type;
     
     /**
      * Return the modifier type (tax, discount, other, ...)
-     *
-     * @return string
      */
-    public function type() : string
+    public function type(): string
     {
         return $this->type;
     }
 
     /**
      * Define the modifier type (tax, discount, other, ...)
-     *
-     * @param null|string $type
-     * @return $this
      */
-    public function setType($type = null)
+    public function setType(?string $type = null): static
     {
         $this->type = $type;
 
@@ -41,10 +34,8 @@ class AmendableModifier implements PriceAmendable
 
     /**
      * Return the modifier's identification key
-     *
-     * @return null|string
      */
-    public function key() : ?string
+    public function key(): ?string
     {
         return 'foo-bar';
     }
@@ -52,10 +43,8 @@ class AmendableModifier implements PriceAmendable
     /**
      * Get the modifier attributes that should be saved in the
      * price modification history.
-     *
-     * @return null|array
      */
-    public function attributes() : ?array
+    public function attributes(): ?array
     {
         return null;
     }
@@ -63,23 +52,14 @@ class AmendableModifier implements PriceAmendable
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @return bool
      */
-    public function appliesAfterVat() : bool
+    public function appliesAfterVat(): bool
     {
         return false;
     }
 
     /**
      * Apply the modifier on the given Money instance
-     *
-     * @param \Brick\Money\AbstractMoney $build
-     * @param float $units
-     * @param bool $perUnit
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\AbstractMoney
      */
     public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {

--- a/tests/Fixtures/CustomAmendableModifier.php
+++ b/tests/Fixtures/CustomAmendableModifier.php
@@ -6,6 +6,7 @@ use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
+use Brick\Money\AbstractMoney;
 
 class CustomAmendableModifier implements PriceAmendable
 {
@@ -92,14 +93,14 @@ class CustomAmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      *
-     * @param \Brick\Money\Money $build
+     * @param \Brick\Money\AbstractMoney $build
      * @param float $units
      * @param bool $perUnit
-     * @param null|\Brick\Money\Money $exclusive
+     * @param null|\Brick\Money\AbstractMoney $exclusive
      * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\Money
+     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(Money $build, $units, $perUnit, Money $exclusive = null, Vat $vat = null) : ?Money
+    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {
         if($perUnit) {
             return $build->plus($this->tax);

--- a/tests/Fixtures/CustomAmendableModifier.php
+++ b/tests/Fixtures/CustomAmendableModifier.php
@@ -12,23 +12,16 @@ class CustomAmendableModifier implements PriceAmendable
 {
     /**
      * The modifier's addition
-     *
-     * @var \Brick\Money\Money
      */
-    protected $tax;
+    protected Money $tax;
     
     /**
      * The "set" modifier type (tax, discount, other, ...)
-     *
-     * @return null|string
      */
-    protected $type;
+    protected ?string $type;
 
     /**
      * Create a new custom instance
-     *
-     * @param \Brick\Money\Money
-     * @return void
      */
     public function __construct(Money $tax)
     {
@@ -37,21 +30,16 @@ class CustomAmendableModifier implements PriceAmendable
 
     /**
      * Return the modifier type (tax, discount, other, ...)
-     *
-     * @return string
      */
-    public function type() : string
+    public function type(): string
     {
         return $this->type;
     }
 
     /**
      * Define the modifier type (tax, discount, other, ...)
-     *
-     * @param null|string $type
-     * @return $this
      */
-    public function setType($type = null)
+    public function setType(?string $type = null): static
     {
         $this->type = $type;
 
@@ -60,10 +48,8 @@ class CustomAmendableModifier implements PriceAmendable
 
     /**
      * Return the modifier's identification key
-     *
-     * @return null|string
      */
-    public function key() : ?string
+    public function key(): ?string
     {
         return 'bar-foo';
     }
@@ -71,10 +57,8 @@ class CustomAmendableModifier implements PriceAmendable
     /**
      * Get the modifier attributes that should be saved in the
      * price modification history.
-     *
-     * @return null|array
      */
-    public function attributes() : ?array
+    public function attributes(): ?array
     {
         return null;
     }
@@ -82,23 +66,14 @@ class CustomAmendableModifier implements PriceAmendable
     /**
      * Whether the modifier should be applied before the
      * VAT value has been computed.
-     *
-     * @return bool
      */
-    public function appliesAfterVat() : bool
+    public function appliesAfterVat(): bool
     {
         return false;
     }
 
     /**
      * Apply the modifier on the given Money instance
-     *
-     * @param \Brick\Money\AbstractMoney $build
-     * @param float $units
-     * @param bool $perUnit
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\AbstractMoney
      */
     public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
     {

--- a/tests/Fixtures/CustomInvertedFormatter.php
+++ b/tests/Fixtures/CustomInvertedFormatter.php
@@ -10,11 +10,8 @@ class CustomInvertedFormatter extends CustomFormatter
 {
     /**
      * Run the formatter using the provided arguments
-     *
-     * @param array $arguments
-     * @return null|string
      */
-    public function call(array $arguments) : ?string
+    public function call(array $arguments): ?string
     {
         [$value, $locale] = $this->getMoneyAndLocale($arguments);
 

--- a/tests/Fixtures/CustomInvertedFormatter.php
+++ b/tests/Fixtures/CustomInvertedFormatter.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Fixtures;
 
-use Brick\Money\Money;
 use Whitecube\Price\Price;
 use Whitecube\Price\Formatting\CustomFormatter;
+use Brick\Money\AbstractMoney;
 
 class CustomInvertedFormatter extends CustomFormatter
 {
@@ -18,7 +18,7 @@ class CustomInvertedFormatter extends CustomFormatter
     {
         [$value, $locale] = $this->getMoneyAndLocale($arguments);
 
-        if(! is_a($value, Money::class)) {
+        if(! is_a($value, AbstractMoney::class)) {
             return null;
         }
 

--- a/tests/Unit/CreatesInstancesTest.php
+++ b/tests/Unit/CreatesInstancesTest.php
@@ -84,3 +84,12 @@ it('creates instances from parsed string with given units', function() {
     expect($price->__toString())->toBe('EUR 8.80');
     expect($price->units())->toBe(floatval(4));
 });
+
+it('creates instances from rational money', function() {
+    $money = Money::ofMinor(500, 'EUR')->toRational()->dividedBy(3);
+
+    $price = new Price($money);
+
+    expect($price->inclusive()->simplified()->__toString())->toBe('EUR 5/3');
+    expect($price->__toString())->toBe('EUR 1.67');
+});

--- a/tests/Unit/FormatsPricesTest.php
+++ b/tests/Unit/FormatsPricesTest.php
@@ -88,7 +88,7 @@ it('cannot format monetary values using a formatter class that does not extend C
     };
 
     Price::formatUsing($formatter);
-})->throws(\InvalidArgumentException::class);
+})->throws(\TypeError::class);
 
 it('formats monetary values using the default formatter despite of the previously defined custom formatter closure', function() {
     setlocale(LC_ALL, 'en_US.UTF-8');

--- a/tests/Unit/HasModifiersTest.php
+++ b/tests/Unit/HasModifiersTest.php
@@ -120,15 +120,15 @@ it('can perform modifier absolute value', function() {
 
 it('cannot add a NULL modifier', function() {
     Price::EUR(500, 2)->addModifier('custom', null);
-})->throws(\InvalidArgumentException::class);
+})->throws(\TypeError::class);
 
 it('cannot add an invalid modifier', function() {
     Price::EUR(500, 2)->addModifier('custom', ['something','unusable']);
-})->throws(\InvalidArgumentException::class);
+})->throws(\TypeError::class);
 
 it('cannot add a non-PriceAmendable modifier instance', function() {
     Price::EUR(500, 2)->addModifier('custom', new NonAmendableModifier());
-})->throws(\InvalidArgumentException::class);
+})->throws(\TypeError::class);
 
 it('can add a numeric modifier', function() {
     $price = Price::EUR(500, 2)->addModifier('custom', '-100');


### PR DESCRIPTION
Almost all of the `\Brick\Money\Money` typehints have been replaced with `\Brick\Money\AbstractMoney`, so that instances of `\Brick\Money\RationalMoney` can also be used as a base for Price instances.

This is necessary when doing operations without rounding in order to avoid errors in the end result.

An example of the problem:

We have a base price of 1000 minor units, that we need to divide by 12 and then multiply by 11.

1000 / 12 * 11 = 916,6666666667

Using the regular `Brick\Money\Money` class forces us to specify a rounding mode when doing the division, which means we have a rounded result before doing the multiplication, which introduces an error in the result:

<img width="1022" alt="CleanShot 2023-03-02 at 11 44 08@2x" src="https://user-images.githubusercontent.com/9298484/222406373-df31e4b4-89d2-475d-b315-d4ad40df3e72.png">

The solution is to build the Price instance with a base `Brick\Money\RationalMoney` instance instead, which represents the amount as a fraction and thus does not require rounding.

<img width="1022" alt="CleanShot 2023-03-02 at 11 44 45@2x" src="https://user-images.githubusercontent.com/9298484/222406485-7bebe019-7a59-4760-a3da-138b1d1eabad.png">

Unfortunately, the change to `AbstractMoney` typehints in the `Whitecube\Price\PriceAmendable` interface is a breaking change, so this requires publishing a new major version of this package (3.x ?). 

My changes in this PR are quite conservative, they require the developer to pay attention to what they are doing and puts the responsibility on them to know when they will need to use `RationalMoney` instead of regular `Money` instances.

I think this is dangerous. Maybe this package should instead **always** use `RationalMoney` under the hood, so that division/multiplication is always handled correctly. I don't think there would be any downsides to that approach.
