### PR TITLE
[4.x] Use RationalMoney instead of Money

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,9 @@ $totalCustomTypeModifiers = $price->modifiers(false, 'custom');
 $totalCustomTypeModifiersPerUnit = $price->modifiers(true, 'custom');
 ```
 
+> [!WARNING]  
+> These values return instances of `RationalMoney` instead of regular `Money`, this is to allow your modifiers to return `RationalMoney` values as well. `RationalMoney` objects do not require rounding when doing operations on them. If you want to transform them to regular `Money` objects, you must specify the context and rounding options. [See the `brick/money` documentation](https://github.com/brick/money?tab=readme-ov-file#advanced-calculations) for more info.
+
 ## Output
 
 By default, all handled monetary values are wrapped into a `Brick\Money\Money` object. This should be the only way to manipulate these values in order to [avoid decimal approximation errors](https://stackoverflow.com/questions/3730019/why-not-use-double-or-float-to-represent-currency).

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "brick/money": "0.8.*"
+        "brick/money": "^0.9.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e92af74b1c8d787ec32efa6cf2ee08a",
+    "content-hash": "f1d87500b1035169f65f9bfb952788d2",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.11.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "5.0.0"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -46,12 +46,17 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
+                "bignumber",
                 "brick",
-                "math"
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.11.0"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -59,34 +64,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T23:15:59+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "brick/money",
-            "version": "0.8.1",
+            "version": "0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/money.git",
-                "reference": "25f484a347756b7f3fbe7ad63ed9ad2d87b20004"
+                "reference": "60f8b6ceab2e1c9527e625198a76498fa477804a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/money/zipball/25f484a347756b7f3fbe7ad63ed9ad2d87b20004",
-                "reference": "25f484a347756b7f3fbe7ad63ed9ad2d87b20004",
+                "url": "https://api.github.com/repos/brick/money/zipball/60f8b6ceab2e1c9527e625198a76498fa477804a",
+                "reference": "60f8b6ceab2e1c9527e625198a76498fa477804a",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "~0.10.1 || ~0.11.0",
+                "brick/math": "~0.12.0",
                 "ext-json": "*",
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "brick/varexporter": "~0.3.0",
                 "ext-dom": "*",
                 "ext-pdo": "*",
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.4.3",
-                "vimeo/psalm": "5.14.1"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "suggest": {
                 "ext-intl": "Required to format Money objects"
@@ -109,7 +114,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/money/issues",
-                "source": "https://github.com/brick/money/tree/0.8.1"
+                "source": "https://github.com/brick/money/tree/0.9.0"
             },
             "funding": [
                 {
@@ -117,7 +122,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-23T21:17:11+00:00"
+            "time": "2023-11-26T16:51:39+00:00"
         }
     ],
     "packages-dev": [
@@ -324,16 +329,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -344,7 +349,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -376,9 +381,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -753,35 +758,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -790,7 +795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -819,7 +824,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -827,7 +832,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1072,45 +1077,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1155,7 +1160,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -1171,7 +1176,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
         },
         {
             "name": "psr/container",
@@ -1228,16 +1233,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -1272,9 +1277,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2241,16 +2246,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.8",
+            "version": "v6.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91"
+                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/be5854cee0e8c7b110f00d695d11debdfa1a2a91",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91",
+                "url": "https://api.github.com/repos/symfony/console/zipball/42686880adaacdad1835ee8fc2a9ec5b7bd63998",
+                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998",
                 "shasum": ""
             },
             "require": {
@@ -2315,7 +2320,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.8"
+                "source": "https://github.com/symfony/console/tree/v6.4.11"
             },
             "funding": [
                 {
@@ -2331,7 +2336,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-08-15T22:48:29+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2402,20 +2407,20 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -2461,7 +2466,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2477,24 +2482,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -2539,7 +2544,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2555,24 +2560,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -2620,7 +2625,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2636,24 +2641,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -2700,7 +2705,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2716,7 +2721,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T12:30:46+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2803,16 +2808,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.1",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2"
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/60bc311c74e0af215101235aa6f471bcbc032df2",
-                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2",
+                "url": "https://api.github.com/repos/symfony/string/zipball/6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
+                "reference": "6cd670a6d968eaeb1c77c2e76091c45c56bc367b",
                 "shasum": ""
             },
             "require": {
@@ -2870,7 +2875,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.1"
+                "source": "https://github.com/symfony/string/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -2886,7 +2891,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-04T06:40:14+00:00"
+            "time": "2024-08-12T09:59:40+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -3,7 +3,7 @@
 namespace Whitecube\Price;
 
 use Brick\Money\Money;
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 use Whitecube\Price\Price;
 
 class Calculator
@@ -38,7 +38,7 @@ class Calculator
     /**
      * Return the result for the "VAT" Money build
      */
-    public function vat(bool $perUnit): array|AbstractMoney
+    public function vat(bool $perUnit): array|RationalMoney
     {
         return $this->getCached('vat', $perUnit)
             ?? $this->setCached('vat', $perUnit, $this->getVatResult($perUnit));
@@ -65,7 +65,7 @@ class Calculator
     /**
      * Retrieve a cached value for key and unit mode
      */
-    protected function getCached(string $key, bool $perUnit): null|array|AbstractMoney
+    protected function getCached(string $key, bool $perUnit): null|array|RationalMoney
     {
         return $this->cache[$key][$perUnit ? 'unit' : 'all'] ?? null;
     }
@@ -73,7 +73,7 @@ class Calculator
     /**
      * Set a cached value for key and unit mode
      */
-    protected function setCached(string $key, bool $perUnit, array|AbstractMoney $result): array|AbstractMoney
+    protected function setCached(string $key, bool $perUnit, array|RationalMoney $result): array|RationalMoney
     {
         $this->cache[$key][$perUnit ? 'unit' : 'all'] = $result;
 
@@ -123,12 +123,12 @@ class Calculator
     /**
      * Compute the VAT
      */
-    protected function getVatResult(bool $perUnit): AbstractMoney
+    protected function getVatResult(bool $perUnit): RationalMoney
     {
         $vat = $this->price->vat(true);
 
         if(! $vat) {
-            return Money::zero($this->price->currency(), $this->price->context());
+            return Money::zero($this->price->currency(), $this->price->context())->toRational();
         }
 
         $exclusive = $this->exclusiveBeforeVat($perUnit)['amount'];
@@ -156,7 +156,7 @@ class Calculator
     /**
      * Compute the price for one unit before VAT is applied
      */
-    protected function applyModifier(PriceAmendable $modifier, array $result, bool $perUnit, bool $postVat = false, AbstractMoney $exclusive = null, Vat $vat = null): array
+    protected function applyModifier(PriceAmendable $modifier, array $result, bool $perUnit, bool $postVat = false, RationalMoney $exclusive = null, Vat $vat = null): array
     {
         $updated = $modifier->apply($result['amount'], $this->price->units(), $perUnit, $exclusive, $vat);
 

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -143,11 +143,11 @@ class Calculator
     {
         $result = $this->exclusiveBeforeVat($perUnit);
 
-        $result['amount'] = $result['amount']->plus($this->vat($perUnit), Price::getRounding('vat'));
+        $result['amount'] = $result['amount']->plus($this->vat($perUnit));
 
         $supplement = $this->exclusiveAfterVat($perUnit);
 
-        $result['amount'] = $result['amount']->plus($supplement['amount'], Price::getRounding('exclusive'));
+        $result['amount'] = $result['amount']->plus($supplement['amount']);
         $result['modifications'] = array_merge($result['modifications'], $supplement['modifications']);
 
         return $result;

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -6,7 +6,7 @@ use Whitecube\Price\Price;
 use Whitecube\Price\Modifier;
 use Whitecube\Price\PriceAmendable;
 use Brick\Money\AbstractMoney;
-use Brick\Money\Money;
+use Brick\Money\RationalMoney;
 
 trait HasModifiers
 {
@@ -101,7 +101,7 @@ trait HasModifiers
     /**
      * Return the modification total for all discounts
      */
-    public function discounts(bool $perUnit = false): Money
+    public function discounts(bool $perUnit = false): RationalMoney
     {
         return $this->modifiers($perUnit, Modifier::TYPE_DISCOUNT);
     }
@@ -109,7 +109,7 @@ trait HasModifiers
     /**
      * Return the modification total for all taxes
      */
-    public function taxes(bool $perUnit = false): Money
+    public function taxes(bool $perUnit = false): RationalMoney
     {
         return $this->modifiers($perUnit, Modifier::TYPE_TAX);
     }
@@ -117,9 +117,9 @@ trait HasModifiers
     /**
      * Return the modification total for a given type
      */
-    public function modifiers(bool $perUnit = false, ?string $type = null): Money
+    public function modifiers(bool $perUnit = false, ?string $type = null): RationalMoney
     {
-        $amount = Money::zero($this->currency());
+        $amount = RationalMoney::of(0, $this->currency());
 
         foreach ($this->modifications($perUnit, $type) as $modification) {
             $amount = $amount->plus($modification['amount']);

--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -68,7 +68,7 @@ trait HasModifiers
             $modifier = $modifier->inclusive();
         }
 
-        return $instance->add($modifier, Price::getRounding('exclusive'));
+        return $instance->add($modifier);
     }
 
     /**

--- a/src/Price.php
+++ b/src/Price.php
@@ -24,7 +24,7 @@ class Price implements \JsonSerializable
     /**
      * The default rounding methods that should be applied when calculating prices
      */
-    static protected ?int $defaultRoundingMode = null;
+    static protected ?RoundingMode $defaultRoundingMode = null;
 
     /**
      * The default Money context that should be applied transforming Rational monies

--- a/src/PriceAmendable.php
+++ b/src/PriceAmendable.php
@@ -2,7 +2,7 @@
 
 namespace Whitecube\Price;
 
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 
 interface PriceAmendable
 {
@@ -35,13 +35,6 @@ interface PriceAmendable
 
     /**
      * Apply the modifier on the given Money instance
-     *
-     * @param \Brick\Money\AbstractMoney $build
-     * @param float $units
-     * @param bool $perUnit
-     * @param null|\Brick\Money\AbstractMoney $exclusive
-     * @param null|\Whitecube\Price\Vat $vat
-     * @return null|\Brick\Money\AbstractMoney
      */
-    public function apply(AbstractMoney $build, float $units, bool $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney;
+    public function apply(RationalMoney $build, float $units, bool $perUnit, RationalMoney $exclusive = null, Vat $vat = null) : ?RationalMoney;
 }

--- a/src/Vat.php
+++ b/src/Vat.php
@@ -4,7 +4,7 @@ namespace Whitecube\Price;
 
 use Brick\Math\BigDecimal;
 use Brick\Math\RoundingMode;
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 use Brick\Money\Money;
 use Whitecube\Price\Price;
 use Brick\Math\BigNumber;
@@ -41,7 +41,7 @@ class Vat
     /**
      * Get the VAT's Money value
      */
-    public function money(bool $perUnit = false): AbstractMoney
+    public function money(bool $perUnit = false): RationalMoney
     {
         return $this->price->build()->vat($perUnit);
     }
@@ -49,10 +49,10 @@ class Vat
     /**
      * Compute the VAT's values
      */
-    public function apply(AbstractMoney $exclusive): AbstractMoney
+    public function apply(RationalMoney $exclusive): RationalMoney
     {
         $multiplier = $this->percentage->dividedBy(100, $this->percentage->getScale() + 2, RoundingMode::UP);
 
-        return $exclusive->multipliedBy($multiplier, Price::getRounding('vat'));
+        return $exclusive->multipliedBy($multiplier);
     }
 }

--- a/tests/Fixtures/AfterVatAmendableModifier.php
+++ b/tests/Fixtures/AfterVatAmendableModifier.php
@@ -6,7 +6,7 @@ use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 
 class AfterVatAmendableModifier implements PriceAmendable
 {
@@ -62,7 +62,7 @@ class AfterVatAmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      */
-    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
+    public function apply(RationalMoney $build, $units, $perUnit, RationalMoney $exclusive = null, Vat $vat = null) : ?RationalMoney
     {
         $tax = Money::ofMinor(100, 'EUR');
 

--- a/tests/Fixtures/AmendableModifier.php
+++ b/tests/Fixtures/AmendableModifier.php
@@ -5,7 +5,7 @@ namespace Tests\Fixtures;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 
 class AmendableModifier implements PriceAmendable
 {
@@ -61,7 +61,7 @@ class AmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      */
-    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
+    public function apply(RationalMoney $build, $units, $perUnit, RationalMoney $exclusive = null, Vat $vat = null) : ?RationalMoney
     {
         return $build->multipliedBy(1.25, RoundingMode::HALF_UP);
     }

--- a/tests/Fixtures/CustomAmendableModifier.php
+++ b/tests/Fixtures/CustomAmendableModifier.php
@@ -6,7 +6,7 @@ use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Whitecube\Price\Vat;
 use Whitecube\Price\PriceAmendable;
-use Brick\Money\AbstractMoney;
+use Brick\Money\RationalMoney;
 
 class CustomAmendableModifier implements PriceAmendable
 {
@@ -75,7 +75,7 @@ class CustomAmendableModifier implements PriceAmendable
     /**
      * Apply the modifier on the given Money instance
      */
-    public function apply(AbstractMoney $build, $units, $perUnit, AbstractMoney $exclusive = null, Vat $vat = null) : ?AbstractMoney
+    public function apply(RationalMoney $build, $units, $perUnit, RationalMoney $exclusive = null, Vat $vat = null) : ?RationalMoney
     {
         if($perUnit) {
             return $build->plus($this->tax);

--- a/tests/Unit/HasModifiersTest.php
+++ b/tests/Unit/HasModifiersTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit;
 
+use Brick\Math\RoundingMode;
+use Brick\Money\Context\DefaultContext;
 use Brick\Money\Money;
 use Whitecube\Price\Price;
 use Whitecube\Price\Modifier;
@@ -312,13 +314,13 @@ it('can return modifications totals', function() {
         ->addModifier('something', CustomAmendableModifier::class, Money::ofMinor(100, 'EUR'))
         ->addModifier('custom', AmendableModifier::class);
 
-    expect($price->discounts()->__toString())->toBe('EUR -3.00');
-    expect($price->discounts(true)->__toString())->toBe('EUR -1.50');
+    expect($price->discounts()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR -3.00');
+    expect($price->discounts(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR -1.50');
 
-    expect($price->taxes()->__toString())->toBe('EUR 3.50');
-    expect($price->taxes(true)->__toString())->toBe('EUR 1.75');
+    expect($price->taxes()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 3.50');
+    expect($price->taxes(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 1.75');
 
-    expect($price->modifiers()->__toString())->toBe('EUR 7.63');
-    expect($price->modifiers(true)->__toString())->toBe('EUR 3.81');
-    expect($price->modifiers(false, 'custom')->__toString())->toBe('EUR 5.13');
+    expect($price->modifiers()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 7.63');
+    expect($price->modifiers(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 3.81');
+    expect($price->modifiers(false, 'custom')->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 5.13');
 });


### PR DESCRIPTION
This PR changes the package to use RationalMoney everywhere internally. This move aims to bring greater accuracy and less rounding errors when calculating prices.