### PR TITLE
[4.x] Use RationalMoney when computing modifier totals

### DIFF
--- a/src/Concerns/HasModifiers.php
+++ b/src/Concerns/HasModifiers.php
@@ -6,7 +6,7 @@ use Whitecube\Price\Price;
 use Whitecube\Price\Modifier;
 use Whitecube\Price\PriceAmendable;
 use Brick\Money\AbstractMoney;
-use Brick\Money\Money;
+use Brick\Money\RationalMoney;
 
 trait HasModifiers
 {
@@ -101,7 +101,7 @@ trait HasModifiers
     /**
      * Return the modification total for all discounts
      */
-    public function discounts(bool $perUnit = false): Money
+    public function discounts(bool $perUnit = false): RationalMoney
     {
         return $this->modifiers($perUnit, Modifier::TYPE_DISCOUNT);
     }
@@ -109,7 +109,7 @@ trait HasModifiers
     /**
      * Return the modification total for all taxes
      */
-    public function taxes(bool $perUnit = false): Money
+    public function taxes(bool $perUnit = false): RationalMoney
     {
         return $this->modifiers($perUnit, Modifier::TYPE_TAX);
     }
@@ -117,9 +117,9 @@ trait HasModifiers
     /**
      * Return the modification total for a given type
      */
-    public function modifiers(bool $perUnit = false, ?string $type = null): Money
+    public function modifiers(bool $perUnit = false, ?string $type = null): RationalMoney
     {
-        $amount = Money::zero($this->currency());
+        $amount = RationalMoney::of(0, $this->currency());
 
         foreach ($this->modifications($perUnit, $type) as $modification) {
             $amount = $amount->plus($modification['amount']);

--- a/tests/Unit/HasModifiersTest.php
+++ b/tests/Unit/HasModifiersTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit;
 
+use Brick\Math\RoundingMode;
+use Brick\Money\Context\DefaultContext;
 use Brick\Money\Money;
 use Whitecube\Price\Price;
 use Whitecube\Price\Modifier;
@@ -312,13 +314,13 @@ it('can return modifications totals', function() {
         ->addModifier('something', CustomAmendableModifier::class, Money::ofMinor(100, 'EUR'))
         ->addModifier('custom', AmendableModifier::class);
 
-    expect($price->discounts()->__toString())->toBe('EUR -3.00');
-    expect($price->discounts(true)->__toString())->toBe('EUR -1.50');
+    expect($price->discounts()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR -3.00');
+    expect($price->discounts(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR -1.50');
 
-    expect($price->taxes()->__toString())->toBe('EUR 3.50');
-    expect($price->taxes(true)->__toString())->toBe('EUR 1.75');
+    expect($price->taxes()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 3.50');
+    expect($price->taxes(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 1.75');
 
-    expect($price->modifiers()->__toString())->toBe('EUR 7.63');
-    expect($price->modifiers(true)->__toString())->toBe('EUR 3.81');
-    expect($price->modifiers(false, 'custom')->__toString())->toBe('EUR 5.13');
+    expect($price->modifiers()->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 7.63');
+    expect($price->modifiers(true)->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 3.81');
+    expect($price->modifiers(false, 'custom')->to(new DefaultContext, RoundingMode::HALF_UP)->__toString())->toBe('EUR 5.13');
 });


### PR DESCRIPTION
When working with modifiers, calling `$amount = $amount->plus($modification['amount']);` when computing the total value for the modifiers sometimes results in a `RoundingNecessaryException` (Rounding is necessary to represent the result of the operation at this scale).

This is because the amount of the modifier can return a `RationalMoney` amount, and the total amount is instanciated as a regular `Money` object, so it does not know how to handle rounding by default.

This PR fixes it by instanciating the total as a RationalMoney object instead, which does not result in a rounding exception. This may be a breaking change, but it's the only way we can allow modifiers to return a `RationalMoney` value without crashing.

---

This PR is intended for 4.x-beta versions, but the 4.x stable release will feature a broader rework to move towards a more complete RationalMoney usage.

See #15 