### PR TITLE
Fix property not initialized error on jsonSerialize

### DIFF
--- a/src/Price.php
+++ b/src/Price.php
@@ -39,7 +39,7 @@ class Price implements \JsonSerializable
     /**
      * The VAT definition
      */
-    protected ?Vat $vat;
+    protected ?Vat $vat = null;
 
     /**
      * The price modifiers to apply

--- a/src/Price.php
+++ b/src/Price.php
@@ -241,7 +241,7 @@ class Price implements \JsonSerializable
             'base' => $this->getRational($this->base)->getAmount(),
             'currency' => $this->base->getCurrency()->getCurrencyCode(),
             'units' => $this->units,
-            'vat' => $this->vat->percentage(),
+            'vat' => $this->vat?->percentage(),
             'total' => [
                 'exclusive' => $this->getRational($excl)->getAmount(),
                 'inclusive' => $this->getRational($incl)->getAmount(),

--- a/tests/Unit/HasVatTest.php
+++ b/tests/Unit/HasVatTest.php
@@ -68,3 +68,9 @@ it('returns inclusive amount with VAT when defined', function() {
     expect($instance->inclusive(true)->__toString())->toBe('EUR 5.50');
 });
 
+it('does not throw an exception when serializing a price with no vat', function () {
+    $instance = Price::ofMinor(500, 'EUR')->setUnits(3);
+
+    expect($instance->jsonSerialize())
+        ->toBeArray();
+});


### PR DESCRIPTION
This PR fixes a PHP exception that occurs when json serializing a price that does not have a vat set.